### PR TITLE
Fixed missing comma, quarto render should function in BP directory now.

### DIFF
--- a/blog-post/refs.bib
+++ b/blog-post/refs.bib
@@ -18,7 +18,7 @@ numpages = {35},
 keywords = {swarm intelligence, learning optimization, Evolutionary computation}
 }
 
-@article{Lewontin1970units
+@article{Lewontin1970units,
  ISSN = {00664162},
  URL = {http://www.jstor.org/stable/2096764},
  author = {R. C. Lewontin},


### PR DESCRIPTION
added missing comma in refs.bib